### PR TITLE
ENG-2085: Update pyonfleet version for export

### DIFF
--- a/api-tools/export-tasks/requirements.txt
+++ b/api-tools/export-tasks/requirements.txt
@@ -2,6 +2,6 @@ certifi==2019.3.9
 chardet==3.0.4
 configparser==3.7.4
 idna==2.8
-pyonfleet==1.0.1
+pyonfleet
 requests==2.22.0
 urllib3==1.25.3


### PR DESCRIPTION
The version specified in requirements.txt (1.0.1) is older and
we should use the latest (currently 1.1.0) because it no longer
requires /usr/config/config.json to be used.