### PR TITLE
Update requirements.txt

### DIFF
--- a/api-tools/webhooks/requirements.txt
+++ b/api-tools/webhooks/requirements.txt
@@ -3,4 +3,4 @@ Flask==1.0.3
 itsdangerous==1.1.0
 Jinja2==2.10.1
 MarkupSafe==1.1.1
-Werkzeug==0.15.4
+Werkzeug==0.15.5


### PR DESCRIPTION
## Bug
`flask run` raises `TypeError: required field "type_ignores" missing from Module`. I believe this is only related to newer versions of python.

For more info, see here
https://stackoverflow.com/questions/60140174/basic-flask-app-not-running-typeerror-required-field-type-ignores-missing-fr

## Changes 
Updates requirements.txt

